### PR TITLE
Switched to use Google original Volley instead of forked version

### DIFF
--- a/libLifeLog/build.gradle
+++ b/libLifeLog/build.gradle
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.mcxiaoke.volley:library:1.0.15'
+    compile 'com.android.volley:volley:1.0.0'
 }

--- a/libLifeLog/src/main/java/com/sonymobile/lifelog/auth/GetAuthTokenTask.java
+++ b/libLifeLog/src/main/java/com/sonymobile/lifelog/auth/GetAuthTokenTask.java
@@ -14,6 +14,8 @@ import com.sonymobile.lifelog.utils.VolleySingleton;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.nio.charset.Charset;
+
 /**
  * Created by championswimmer on 21/4/15.
  */
@@ -47,7 +49,7 @@ public class GetAuthTokenTask {
 
         JsonObjectRequest authRequest = new JsonObjectRequest(Request.Method.POST,
                 OAUTH2_URL,
-                authRequestBody,
+                (JSONObject)null,
                 new Response.Listener<JSONObject>() {
                     @Override
                     public void onResponse(JSONObject jObj) {
@@ -82,6 +84,12 @@ public class GetAuthTokenTask {
             public String getBodyContentType() {
                 return String.format("application/x-www-form-urlencoded; charset=%s", new Object[]{"utf-8"});
             }
+
+            @Override
+            public byte[] getBody() {
+                return authRequestBody.getBytes(Charset.forName("utf-8"));
+            }
+
         };
         VolleySingleton.getInstance(mContext).addToRequestQueue(authRequest);
     }

--- a/libLifeLog/src/main/java/com/sonymobile/lifelog/auth/RefreshAuthTokenTask.java
+++ b/libLifeLog/src/main/java/com/sonymobile/lifelog/auth/RefreshAuthTokenTask.java
@@ -14,6 +14,8 @@ import com.sonymobile.lifelog.utils.VolleySingleton;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.nio.charset.Charset;
+
 /**
  * Created by championswimmer on 21/4/15.
  */
@@ -51,7 +53,7 @@ public class RefreshAuthTokenTask {
 
         JsonObjectRequest authRequest = new JsonObjectRequest(Request.Method.POST,
                 OAUTH2_URL,
-                refreshAuthBody,
+                null,
                 new Response.Listener<JSONObject>() {
                     @Override
                     public void onResponse(JSONObject jObj) {
@@ -85,6 +87,12 @@ public class RefreshAuthTokenTask {
             public String getBodyContentType() {
                 return String.format("application/x-www-form-urlencoded; charset=%s", new Object[]{"utf-8"});
             }
+
+            @Override
+            public byte[] getBody() {
+                return refreshAuthBody.getBytes(Charset.forName("utf-8"));
+            }
+
         };
         VolleySingleton.getInstance(mContext).addToRequestQueue(authRequest);
     }


### PR DESCRIPTION
Since Google released original version of Volley to jCenter and mcxiaoke's Volley library is now deprecated, switched to use Google version. Some API available in the forked version is not available in Google side original version, so API signature is slightly changed.
