### PR TITLE
Updated handling of auth token to simplify logout operation

### DIFF
--- a/app/src/main/java/in/championswimmer/lifelog/MainActivity.java
+++ b/app/src/main/java/in/championswimmer/lifelog/MainActivity.java
@@ -12,6 +12,7 @@ import android.widget.Toast;
 
 import com.sonymobile.lifelog.LifeLog;
 import com.sonymobile.lifelog.api.LifeLogLocationAPI;
+import com.sonymobile.lifelog.utils.SecurePreferences;
 
 import java.util.ArrayList;
 
@@ -25,11 +26,20 @@ public class MainActivity extends ActionBarActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        Button b = (Button) findViewById(R.id.login_button);
-        b.setOnClickListener(new View.OnClickListener() {
+        Button login = (Button) findViewById(R.id.login_button);
+        login.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 LifeLog.doLogin(MainActivity.this);
+            }
+        });
+
+        Button logout = (Button) findViewById(R.id.logout_button);
+        logout.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                SecurePreferences preferences = LifeLog.getSecurePreference(MainActivity.this);
+                preferences.clear();
             }
         });
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,15 +8,17 @@
     android:paddingTop="@dimen/activity_vertical_margin"
     tools:context=".MainActivity">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/hello_world" />
-
     <Button
         android:id="@+id/login_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="LOGIN" />
+
+    <Button
+        android:id="@+id/logout_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/login_button"
+        android:text="LOGOUT" />
 
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,5 @@
 <resources>
     <string name="app_name">Sample Lifelog App</string>
 
-    <string name="hello_world">Hello world!</string>
     <string name="action_settings">Settings</string>
 </resources>

--- a/libLifeLog/build.gradle
+++ b/libLifeLog/build.gradle
@@ -21,4 +21,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.volley:volley:1.0.0'
+    compile 'com.android.support:support-annotations:22.2.0'
 }

--- a/libLifeLog/src/main/java/com/sonymobile/lifelog/LifeLog.java
+++ b/libLifeLog/src/main/java/com/sonymobile/lifelog/LifeLog.java
@@ -18,7 +18,8 @@ public class LifeLog {
 
     public static final String API_BASE_URL = "https://platform.lifelog.sonymobile.com";
 
-    public static final String LIFELOG_PREFS = "lifelog_prefs";
+    // file name of preference
+    private static final String LIFELOG_PREFS = "lifelog_prefs";
     static String client_id = "";
     static String client_secret = "";
     static String login_scope = "";
@@ -63,6 +64,10 @@ public class LifeLog {
         }
     }
 
+    public static SecurePreferences getSecurePreference(Context context) {
+        return new SecurePreferences(context, LifeLog.LIFELOG_PREFS, LifeLog.getClient_secret(), true);
+    }
+
     /**
      * Initiate login operation with {@link com.sonymobile.lifelog.LifeLog#LOGINACTIVITY_REQUEST_CODE},
      * callback will be delivered to {@link Activity#onActivityResult(int, int, Intent)}.
@@ -73,12 +78,7 @@ public class LifeLog {
     }
 
     public static void checkAuthentication (Context context, final OnAuthenticationChecked oac) {
-        SecurePreferences securePreferences = new SecurePreferences(
-                context,
-                LIFELOG_PREFS,
-                getClient_secret(),
-                true
-        );
+        SecurePreferences securePreferences = getSecurePreference(context);
         if (securePreferences.containsKey(GetAuthTokenTask.AUTH_ACCESS_TOKEN)) {
             auth_token = securePreferences.getString(GetAuthTokenTask.AUTH_ACCESS_TOKEN);
             long expires_in = Long.valueOf(securePreferences.getString(GetAuthTokenTask.AUTH_EXPIRES_IN));

--- a/libLifeLog/src/main/java/com/sonymobile/lifelog/LifeLog.java
+++ b/libLifeLog/src/main/java/com/sonymobile/lifelog/LifeLog.java
@@ -3,6 +3,7 @@ package com.sonymobile.lifelog;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.sonymobile.lifelog.auth.GetAuthTokenTask;
@@ -24,7 +25,6 @@ public class LifeLog {
     static String client_secret = "";
     static String login_scope = "";
     static String callback_url = "";
-    static String auth_token = "";
 
     public static String getClient_id() {
         return client_id;
@@ -38,8 +38,10 @@ public class LifeLog {
         return callback_url;
     }
 
-    public static String getAuth_token() {
-        return auth_token;
+    @Nullable
+    public static String getAuthToken(Context context) {
+        SecurePreferences preference = getSecurePreference(context);
+        return preference.getString(GetAuthTokenTask.AUTH_ACCESS_TOKEN);
     }
 
     public static void initialise(String id, String secret, String callbackUrl) {
@@ -80,7 +82,6 @@ public class LifeLog {
     public static void checkAuthentication (Context context, final OnAuthenticationChecked oac) {
         SecurePreferences securePreferences = getSecurePreference(context);
         if (securePreferences.containsKey(GetAuthTokenTask.AUTH_ACCESS_TOKEN)) {
-            auth_token = securePreferences.getString(GetAuthTokenTask.AUTH_ACCESS_TOKEN);
             long expires_in = Long.valueOf(securePreferences.getString(GetAuthTokenTask.AUTH_EXPIRES_IN));
             if (expires_in > 120) {
                 oac.onAuthChecked(true);
@@ -89,7 +90,6 @@ public class LifeLog {
                 ratt.refreshAuth(new RefreshAuthTokenTask.OnAuthenticatedListener() {
                     @Override
                     public void onAuthenticated(String token) {
-                        auth_token = token;
                         oac.onAuthChecked(true);
                     }
                 });

--- a/libLifeLog/src/main/java/com/sonymobile/lifelog/LoginActivity.java
+++ b/libLifeLog/src/main/java/com/sonymobile/lifelog/LoginActivity.java
@@ -57,8 +57,6 @@ public class LoginActivity extends Activity {
                         gat.getAuth(authenticationCode, new GetAuthTokenTask.OnAuthenticatedListener() {
                             @Override
                             public void onAuthenticated(String authToken) {
-                                LifeLog.auth_token = authToken;
-
                                 dialog.dismiss();
 
                                 setResult(RESULT_OK);

--- a/libLifeLog/src/main/java/com/sonymobile/lifelog/api/LifeLogLocationAPI.java
+++ b/libLifeLog/src/main/java/com/sonymobile/lifelog/api/LifeLogLocationAPI.java
@@ -65,7 +65,7 @@ public class LifeLogLocationAPI {
         LifeLog.checkAuthentication(context, new LifeLog.OnAuthenticationChecked() {
             @Override
             public void onAuthChecked(boolean authenticated) {
-                authToken = LifeLog.getAuth_token();
+                authToken = LifeLog.getAuthToken(context);
             }
         });
         String requestUrl = LOCATION_BASE_URL;

--- a/libLifeLog/src/main/java/com/sonymobile/lifelog/auth/GetAuthTokenTask.java
+++ b/libLifeLog/src/main/java/com/sonymobile/lifelog/auth/GetAuthTokenTask.java
@@ -55,8 +55,7 @@ public class GetAuthTokenTask {
                     @Override
                     public void onResponse(JSONObject jObj) {
                         try {
-                            SecurePreferences spref = new SecurePreferences(mContext,
-                                    LifeLog.LIFELOG_PREFS, LifeLog.getClient_secret(), true);
+                            SecurePreferences spref = LifeLog.getSecurePreference(mContext);
                             spref.put(AUTH_ACCESS_TOKEN, jObj.getString(AUTH_ACCESS_TOKEN));
                             spref.put(AUTH_EXPIRES_IN, jObj.getString(AUTH_EXPIRES_IN));
                             spref.put(AUTH_TOKEN_TYPE, jObj.getString(AUTH_TOKEN_TYPE));

--- a/libLifeLog/src/main/java/com/sonymobile/lifelog/auth/RefreshAuthTokenTask.java
+++ b/libLifeLog/src/main/java/com/sonymobile/lifelog/auth/RefreshAuthTokenTask.java
@@ -40,8 +40,7 @@ public class RefreshAuthTokenTask {
 
     public void refreshAuth(OnAuthenticatedListener oal) {
         onAuthenticatedListener = oal;
-        final SecurePreferences spref = new SecurePreferences(mContext,
-                LifeLog.LIFELOG_PREFS, LifeLog.getClient_secret(), true);
+        final SecurePreferences spref = LifeLog.getSecurePreference(mContext);
 
         final String refreshAuthBody =
                 PARAM_CLIENT_ID + "=" + LifeLog.getClient_id() + "&"


### PR DESCRIPTION
Hi.

I made update for handling of auth token, in order to basically simplify logout operation. Previously, auth token was saved in both of static member and preference, so logic needed to clear both in case of logout. By using preference always for auth token, library logic was simplified especially for logout handling.

Hope you like this pull request.
