### PR TITLE
Fixed expire time calculation logic of refreshing auth token

### DIFF
--- a/libLifeLog/src/main/java/com/sonymobile/lifelog/LifeLog.java
+++ b/libLifeLog/src/main/java/com/sonymobile/lifelog/LifeLog.java
@@ -79,11 +79,20 @@ public class LifeLog {
         activity.startActivityForResult(loginIntent, LOGINACTIVITY_REQUEST_CODE);
     }
 
+    /**
+     * Refresh access token if it is about to expire
+     */
     public static void checkAuthentication(Context context, final OnAuthenticationChecked oac) {
+        context = context.getApplicationContext();
         SecurePreferences securePreferences = getSecurePreference(context);
         if (securePreferences.containsKey(GetAuthTokenTask.AUTH_ACCESS_TOKEN)) {
-            long expires_in = Long.valueOf(securePreferences.getString(GetAuthTokenTask.AUTH_EXPIRES_IN));
-            if (expires_in > 120) {
+            long expiresIn = Long
+                    .valueOf(securePreferences.getString(GetAuthTokenTask.AUTH_EXPIRES_IN));
+            long issueAt = Long
+                    .valueOf(securePreferences.getString(GetAuthTokenTask.AUTH_ISSUE_AT));
+
+            // if access token expires in next 2 minutes
+            if (issueAt + expiresIn - System.currentTimeMillis() / 1000 > 120) {
                 oac.onAuthChecked(true);
             } else {
                 RefreshAuthTokenTask ratt = new RefreshAuthTokenTask(context);

--- a/libLifeLog/src/main/java/com/sonymobile/lifelog/auth/GetAuthTokenTask.java
+++ b/libLifeLog/src/main/java/com/sonymobile/lifelog/auth/GetAuthTokenTask.java
@@ -24,6 +24,7 @@ public class GetAuthTokenTask {
 
     public static final String AUTH_ACCESS_TOKEN = "access_token";
     public static final String AUTH_EXPIRES_IN = "expires_in";
+    public static final String AUTH_ISSUE_AT = "issue_at";
     public static final String AUTH_REFRESH_TOKEN = "refresh_token";
     public static final String AUTH_TOKEN_TYPE = "token_type";
     public static final String AUTH_REFRESH_TOKEN_EXPIRES_IN = "refresh_token_expires_in";
@@ -58,6 +59,7 @@ public class GetAuthTokenTask {
                         try {
                             SecurePreferences spref = LifeLog.getSecurePreference(mContext);
                             spref.put(AUTH_ACCESS_TOKEN, jObj.getString(AUTH_ACCESS_TOKEN));
+                            spref.put(AUTH_ISSUE_AT, String.valueOf(System.currentTimeMillis() / 1000));
                             spref.put(AUTH_EXPIRES_IN, jObj.getString(AUTH_EXPIRES_IN));
                             spref.put(AUTH_TOKEN_TYPE, jObj.getString(AUTH_TOKEN_TYPE));
                             spref.put(AUTH_REFRESH_TOKEN, jObj.getString(AUTH_REFRESH_TOKEN));


### PR DESCRIPTION
"expires_in" parameter value from web API indicates expire time in second since web API call time. Logic is updated to use the value correctly.
