### PR TITLE
Removed dead code in API request code

### DIFF
--- a/libLifeLog/src/main/java/com/sonymobile/lifelog/api/requests/MeLocationRequest.java
+++ b/libLifeLog/src/main/java/com/sonymobile/lifelog/api/requests/MeLocationRequest.java
@@ -31,7 +31,6 @@ import java.util.Map;
 public class MeLocationRequest {
 
     public static final String TAG = "LifeLog:LocationAPI";
-    static JsonObjectRequest lastLocationRequest;
     String startTime, endTime;
     Integer limit;
     String authToken;
@@ -89,30 +88,11 @@ public class MeLocationRequest {
                             Log.v(TAG, jsonObject.toString());
                         }
                         try {
-                            if (jsonObject.has("error")) {
-                                if (jsonObject.getJSONObject("error").getString("code").contains("401")) {
-                                    LifeLog.checkAuthentication(appContext, new LifeLog.OnAuthenticationChecked() {
-                                        @Override
-                                        public void onAuthChecked(boolean authenticated) {
-                                            if (authenticated && (lastLocationRequest != null))
-                                                VolleySingleton.getInstance(appContext).addToRequestQueue(lastLocationRequest);
-                                        }
-                                    });
-                                }
-                            }
-                        } catch (Exception e) {
-                            if (Debug.isDebuggable(appContext)) {
-                                Log.w(TAG, "Exception", e);
-                            }
-                        }
-
-                        try {
                             JSONArray resultArray = jsonObject.getJSONArray("result");
                             for (int i = 0; i < resultArray.length(); i++) {
                                 locations.add(new MeLocation(resultArray.getJSONObject(i)));
                             }
                             olf.onLocationFetched(locations);
-                            lastLocationRequest = null;
                         } catch (JSONException e) {
                             if (Debug.isDebuggable(appContext)) {
                                 Log.w(TAG, "JSONException", e);
@@ -141,7 +121,6 @@ public class MeLocationRequest {
                 return headerMap;
             }
         };
-        lastLocationRequest = locationRequest;
         VolleySingleton.getInstance(appContext).addToRequestQueue(locationRequest);
     }
 

--- a/libLifeLog/src/main/java/com/sonymobile/lifelog/api/requests/MeRequest.java
+++ b/libLifeLog/src/main/java/com/sonymobile/lifelog/api/requests/MeRequest.java
@@ -26,7 +26,6 @@ import java.util.Map;
 public class MeRequest {
 
     public static final String TAG = "LifeLog:MeRequest";
-    static JsonObjectRequest lastMeRequest;
     static String API_URL = LifeLog.API_BASE_URL + "/users/me";
     String authToken;
 
@@ -58,22 +57,6 @@ public class MeRequest {
                     public void onResponse(JSONObject jsonObject) {
                         Log.v(TAG, jsonObject.toString());
                         try {
-                            if (jsonObject.has("error")) {
-                                if (jsonObject.getJSONObject("error").getString("code").contains("401")) {
-                                    LifeLog.checkAuthentication(context, new LifeLog.OnAuthenticationChecked() {
-                                        @Override
-                                        public void onAuthChecked(boolean authenticated) {
-                                            if (authenticated && (lastMeRequest != null))
-                                                VolleySingleton.getInstance(context).addToRequestQueue(lastMeRequest);
-                                        }
-                                    });
-                                }
-                            }
-                        } catch (Exception e) {
-                            e.printStackTrace();
-                        }
-
-                        try {
                             JSONArray resultArray = jsonObject.getJSONArray("result");
                             JSONObject meObject = resultArray.getJSONObject(0);
 
@@ -81,8 +64,6 @@ public class MeRequest {
                             Me meData = gson.fromJson(meObject.toString(), Me.class);
 
                             omf.onMeFetched(meData);
-
-                            lastMeRequest = null;
                         } catch (JSONException e) {
                             e.printStackTrace();
                         }
@@ -107,7 +88,6 @@ public class MeRequest {
                 return headerMap;
             }
         };
-        lastMeRequest = meRequest;
         VolleySingleton.getInstance(context).addToRequestQueue(meRequest);
 
     }


### PR DESCRIPTION
In case of 401 error response from server, onErrorResponse will be called by Volley framework. So handling of 401 error in onResponse is dead code.
