### PR TITLE
Split internal logic of api calls to secure token refresh beforehand

### DIFF
--- a/libLifeLog/src/main/java/com/sonymobile/lifelog/api/requests/MeLocationRequest.java
+++ b/libLifeLog/src/main/java/com/sonymobile/lifelog/api/requests/MeLocationRequest.java
@@ -33,7 +33,6 @@ public class MeLocationRequest {
     public static final String TAG = "LifeLog:LocationAPI";
     String startTime, endTime;
     Integer limit;
-    String authToken;
 
     private static final Uri LOCATION_BASE_URL =
             Uri.parse(LifeLog.API_BASE_URL).buildUpon().appendEncodedPath("users/me/locations").build();
@@ -60,13 +59,18 @@ public class MeLocationRequest {
         if (Debug.isDebuggable(appContext)) {
             Log.v(TAG, "get called");
         }
-        final ArrayList<MeLocation> locations = new ArrayList<>(limit);
         LifeLog.checkAuthentication(appContext, new LifeLog.OnAuthenticationChecked() {
             @Override
             public void onAuthChecked(boolean authenticated) {
-                authToken = LifeLog.getAuthToken(appContext);
+                if (authenticated) {
+                    callLocationApi(appContext, olf);
+                }
             }
         });
+    }
+
+    private void callLocationApi(final Context appContext, final OnLocationFetched olf) {
+        final ArrayList<MeLocation> locations = new ArrayList<>(limit);
 
         Uri.Builder uriBuilder = LOCATION_BASE_URL.buildUpon();
         if (!TextUtils.isEmpty(startTime)) {
@@ -114,7 +118,7 @@ public class MeLocationRequest {
             @Override
             public Map<String, String> getHeaders() throws AuthFailureError {
                 Map<String, String> headerMap = new HashMap<>(5);
-                headerMap.put("Authorization", "Bearer " + authToken);
+                headerMap.put("Authorization", "Bearer " + LifeLog.getAuthToken(appContext));
                 headerMap.put("Accept", "application/json");
                 //headerMap.put("Accept-Encoding", "gzip");
                 //headerMap.put("Content-Encoding", "gzip");

--- a/libLifeLog/src/main/java/com/sonymobile/lifelog/api/requests/MeRequest.java
+++ b/libLifeLog/src/main/java/com/sonymobile/lifelog/api/requests/MeRequest.java
@@ -27,7 +27,6 @@ public class MeRequest {
 
     public static final String TAG = "LifeLog:MeRequest";
     static String API_URL = LifeLog.API_BASE_URL + "/users/me";
-    String authToken;
 
     Gson gson;
 
@@ -40,14 +39,22 @@ public class MeRequest {
     }
 
     public void get(final Context context, final OnMeFetched omf) {
-        Log.v(TAG, "get called");
+        if (Debug.isDebuggable(context)) {
+            Log.v(TAG, "get called");
+        }
+        final Context appContext = context.getApplicationContext();
 
-        LifeLog.checkAuthentication(context, new LifeLog.OnAuthenticationChecked() {
+        LifeLog.checkAuthentication(appContext, new LifeLog.OnAuthenticationChecked() {
             @Override
             public void onAuthChecked(boolean authenticated) {
-                authToken = LifeLog.getAuthToken(context);
+                if (authenticated) {
+                    callMeApi(appContext, omf);
+                }
             }
         });
+    }
+
+    private void callMeApi(final Context appContext, final OnMeFetched omf) {
         String requestUrl = API_URL;
 
         final JsonObjectRequest meRequest = new JsonObjectRequest(Request.Method.GET,
@@ -81,14 +88,14 @@ public class MeRequest {
             @Override
             public Map<String, String> getHeaders() throws AuthFailureError {
                 Map<String, String> headerMap = new HashMap<>(5);
-                headerMap.put("Authorization", "Bearer " + authToken);
+                headerMap.put("Authorization", "Bearer " + LifeLog.getAuthToken(appContext));
                 headerMap.put("Accept", "application/json");
                 //headerMap.put("Accept-Encoding", "gzip");
                 //headerMap.put("Content-Encoding", "gzip");
                 return headerMap;
             }
         };
-        VolleySingleton.getInstance(context).addToRequestQueue(meRequest);
+        VolleySingleton.getInstance(appContext).addToRequestQueue(meRequest);
 
     }
 


### PR DESCRIPTION
Original code has timing issue of auth token retrival, when auth token expired and refresh is required. Internal logic of API call is updated to ensure auth token refresh before actual API call, if required.
