### PR TITLE
Call start method of Volley thread to ensure auth operation start

### DIFF
--- a/libLifeLog/src/main/java/com/sonymobile/lifelog/auth/GetAuthTokenTask.java
+++ b/libLifeLog/src/main/java/com/sonymobile/lifelog/auth/GetAuthTokenTask.java
@@ -100,7 +100,13 @@ public class GetAuthTokenTask {
             }
 
         };
-        VolleySingleton.getInstance(mContext).addToRequestQueue(authRequest);
+
+        VolleySingleton volley = VolleySingleton.getInstance(mContext);
+        volley.addToRequestQueue(authRequest);
+
+        // VolleySingleton is public and visible, client app may stop the thread of Volley to suppress
+        // battery consumption etc. Call start API explicitly to ensure for operation start
+        volley.getRequestQueue().start();
     }
 
 }


### PR DESCRIPTION
Hi.

Because VolleySingleton class is public and visible, client app may stop the thread of Volley to suppress battery consumption etc. Call start API explicitly to ensure for operation start.

Actually my application stops the thread of Volley by synchronization of UI lifecycle of main Activity, for better battery consumption. So previous version of this library does not work properly for acquiring of auth token.

I hope you like this patch.
