### PR TITLE
Added logic to remove credential data when server respond HTTP 400

### DIFF
--- a/libLifeLog/src/main/java/com/sonymobile/lifelog/auth/GetTokenJsonRequest.java
+++ b/libLifeLog/src/main/java/com/sonymobile/lifelog/auth/GetTokenJsonRequest.java
@@ -87,8 +87,18 @@ import java.nio.charset.Charset;
         @Override
         public void onErrorResponse(VolleyError error) {
             if (Debug.isDebuggable(mContext)) {
-                Log.w(TAG, "VolleyError: " + new String(error.networkResponse.data), error);
+                Log.w(TAG, "VolleyError, status code: " + error.networkResponse.statusCode
+                        + ", message: " + new String(error.networkResponse.data), error);
             }
+
+            if (error.networkResponse.statusCode == 400) {
+                if (Debug.isDebuggable(mContext)) {
+                    Log.w(TAG, "User may revoked permission of the app from Lifelog service, clear token data.");
+                }
+                SecurePreferences preference = LifeLog.getSecurePreference(mContext);
+                preference.clear();
+            }
+
             if (mListener != null) {
                 mListener.onError(error);
             }


### PR DESCRIPTION
When user revokes permission of the app from Lifelog web page (https://connectedapps.lifelog.sonymobile.com/), server responds with HTTP 400 error code for API call from client. So added logic to clear credential data in such case.
