### PR TITLE
Add support of pagination of location API data response

### DIFF
--- a/app/src/main/java/in/championswimmer/lifelog/MainActivity.java
+++ b/app/src/main/java/in/championswimmer/lifelog/MainActivity.java
@@ -55,11 +55,26 @@ public class MainActivity extends ActionBarActivity {
                     logout.setVisibility(View.VISIBLE);
                     login.setVisibility(View.GONE);
                     Toast.makeText(MainActivity.this, "authed", Toast.LENGTH_SHORT).show();
-                    MeLocationRequest llLocation = MeLocationRequest.prepareRequest(500);
+                    final MeLocationRequest llLocation = MeLocationRequest.prepareRequest(500);
                     llLocation.get(MainActivity.this, new MeLocationRequest.OnLocationFetched() {
+
+                        private int mPage = 0;
+
                         @Override
                         public void onLocationFetched(ArrayList<MeLocation> locations) {
-                            Log.d(TAG, locations.get(0).getId());
+                            Log.d(TAG, "Page number: " + mPage + ", " + locations.size() + " points of location data fetched.");
+
+                            if (mPage >= 9) {
+                                Log.d(TAG, "10 pages of data fetched, finish fetching.");
+                                return;
+                            }
+
+                            if (llLocation.getNextPage(MainActivity.this, this)) {
+                                mPage++;
+                                Log.d(TAG, "Next page of pagination is available, requested the next page data");
+                            } else {
+                                Log.d(TAG, "Fetching finished until last page");
+                            }
 
                         }
                     });

--- a/app/src/main/java/in/championswimmer/lifelog/MainActivity.java
+++ b/app/src/main/java/in/championswimmer/lifelog/MainActivity.java
@@ -18,7 +18,7 @@ import com.sonymobile.lifelog.api.requests.MeLocationRequest;
 import com.sonymobile.lifelog.api.requests.MeRequest;
 import com.sonymobile.lifelog.utils.SecurePreferences;
 
-import java.util.ArrayList;
+import java.util.List;
 
 
 public class MainActivity extends ActionBarActivity {
@@ -61,7 +61,7 @@ public class MainActivity extends ActionBarActivity {
                         private int mPage = 0;
 
                         @Override
-                        public void onLocationFetched(ArrayList<MeLocation> locations) {
+                        public void onLocationFetched(List<MeLocation> locations) {
                             Log.d(TAG, "Page number: " + mPage + ", " + locations.size() + " points of location data fetched.");
 
                             if (mPage >= 9) {

--- a/libLifeLog/src/main/java/com/sonymobile/lifelog/api/requests/MeLocationRequest.java
+++ b/libLifeLog/src/main/java/com/sonymobile/lifelog/api/requests/MeLocationRequest.java
@@ -24,6 +24,7 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.List;
 
 /**
  * Created by championswimmer on 21/4/15.
@@ -171,7 +172,7 @@ public class MeLocationRequest {
     }
 
     public interface OnLocationFetched {
-        void onLocationFetched(ArrayList<MeLocation> locations);
+        void onLocationFetched(List<MeLocation> locations);
     }
 
 }

--- a/libLifeLog/src/main/java/com/sonymobile/lifelog/api/requests/MeLocationRequest.java
+++ b/libLifeLog/src/main/java/com/sonymobile/lifelog/api/requests/MeLocationRequest.java
@@ -136,7 +136,12 @@ public class MeLocationRequest {
                       @Override
                       public void onErrorResponse(VolleyError volleyError) {
                           if (Debug.isDebuggable(context)) {
-                              Log.w(TAG, "VolleyError: " + new String(volleyError.networkResponse.data), volleyError);
+                              if (volleyError.networkResponse != null) {
+                                  Log.w(TAG, "VolleyError: "
+                                          + new String(volleyError.networkResponse.data), volleyError);
+                              } else {
+                                  Log.w(TAG, volleyError);
+                              }
                           }
                       }
                   });

--- a/libLifeLog/src/main/java/com/sonymobile/lifelog/api/requests/MeLocationRequest.java
+++ b/libLifeLog/src/main/java/com/sonymobile/lifelog/api/requests/MeLocationRequest.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.net.Uri;
 import android.text.TextUtils;
 import android.util.Log;
+import android.webkit.URLUtil;
 
 import com.android.volley.Request;
 import com.android.volley.Response;
@@ -30,6 +31,8 @@ public class MeLocationRequest {
     private static final String TAG = "LifeLog:LocationAPI";
     private String mStartTime, mEndTime;
     private Integer mLimit;
+
+    private String mNextPage;
 
     private static final Uri LOCATION_BASE_URL =
             Uri.parse(LifeLog.API_BASE_URL).buildUpon().appendEncodedPath("users/me/locations").build();
@@ -102,6 +105,20 @@ public class MeLocationRequest {
                               JSONArray resultArray = jsonObject.getJSONArray("result");
                               for (int i = 0; i < resultArray.length(); i++) {
                                   locations.add(new MeLocation(resultArray.getJSONObject(i)));
+                              }
+
+                              JSONArray links = jsonObject.optJSONArray("links");
+                              if (links != null) {
+                                  for (int i = 0; i < links.length(); i++) {
+                                      JSONObject object = links.getJSONObject(i);
+                                      if (TextUtils.equals("next", object.optString("rel"))) {
+                                          String href = object.optString("href");
+                                          if (!TextUtils.isEmpty(href) && URLUtil
+                                                  .isNetworkUrl(href)) {
+                                              mNextPage = href;
+                                          }
+                                      }
+                                  }
                               }
 
                               olf.onLocationFetched(locations);

--- a/libLifeLog/src/main/java/com/sonymobile/lifelog/api/requests/MeLocationRequest.java
+++ b/libLifeLog/src/main/java/com/sonymobile/lifelog/api/requests/MeLocationRequest.java
@@ -28,16 +28,16 @@ import java.util.Calendar;
 public class MeLocationRequest {
 
     private static final String TAG = "LifeLog:LocationAPI";
-    private String startTime, endTime;
-    private Integer limit;
+    private String mStartTime, mEndTime;
+    private Integer mLimit;
 
     private static final Uri LOCATION_BASE_URL =
             Uri.parse(LifeLog.API_BASE_URL).buildUpon().appendEncodedPath("users/me/locations").build();
 
     public MeLocationRequest(Calendar start, Calendar end, Integer lim) {
-        if (start != null) startTime = ISO8601Date.fromCalendar(start);
-        if (end != null) endTime = ISO8601Date.fromCalendar(end);
-        limit = lim;
+        if (start != null) mStartTime = ISO8601Date.fromCalendar(start);
+        if (end != null) mEndTime = ISO8601Date.fromCalendar(end);
+        mLimit = lim;
     }
 
     public static MeLocationRequest prepareRequest(Calendar start, Calendar end, Integer lim) {
@@ -67,17 +67,17 @@ public class MeLocationRequest {
     }
 
     private void callLocationApi(final Context appContext, final OnLocationFetched olf) {
-        final ArrayList<MeLocation> locations = new ArrayList<>(limit);
+        final ArrayList<MeLocation> locations = new ArrayList<>(mLimit);
 
         Uri.Builder uriBuilder = LOCATION_BASE_URL.buildUpon();
-        if (!TextUtils.isEmpty(startTime)) {
-            uriBuilder.appendQueryParameter("start_time", startTime);
+        if (!TextUtils.isEmpty(mStartTime)) {
+            uriBuilder.appendQueryParameter("start_time", mStartTime);
         }
-        if (!TextUtils.isEmpty(endTime)) {
-            uriBuilder.appendQueryParameter("end_time", endTime);
+        if (!TextUtils.isEmpty(mEndTime)) {
+            uriBuilder.appendQueryParameter("end_time", mEndTime);
         }
-        if (limit > 0) {
-            uriBuilder.appendQueryParameter("limit", String.valueOf(limit));
+        if (mLimit > 0) {
+            uriBuilder.appendQueryParameter("limit", String.valueOf(mLimit));
         }
 
         final JsonObjectRequest locationRequest = new AuthedJsonObjectRequest(appContext,

--- a/libLifeLog/src/main/java/com/sonymobile/lifelog/api/requests/MeLocationRequest.java
+++ b/libLifeLog/src/main/java/com/sonymobile/lifelog/api/requests/MeLocationRequest.java
@@ -150,9 +150,9 @@ public class MeLocationRequest {
 
     /**
      * Dispatch call of the location API for next page, if the next page is available for previous
-     * call of {@link #get(Context, OnLocationFetched)}.
+     * call of {@link #get(Context, OnLocationFetched)} by pagination feature of the Lifelog API.
      *
-     * @return true, if next page is available
+     * @return true, if next page of pagination is available
      */
     public boolean getNextPage(@NonNull final Context context, @NonNull final OnLocationFetched olf) {
         if (mNextPage == null) {

--- a/libLifeLog/src/main/java/com/sonymobile/lifelog/api/requests/MeLocationRequest.java
+++ b/libLifeLog/src/main/java/com/sonymobile/lifelog/api/requests/MeLocationRequest.java
@@ -2,6 +2,8 @@ package com.sonymobile.lifelog.api.requests;
 
 import android.content.Context;
 import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
 import android.webkit.URLUtil;
@@ -32,6 +34,7 @@ public class MeLocationRequest {
     private String mStartTime, mEndTime;
     private Integer mLimit;
 
+    @Nullable
     private String mNextPage;
 
     private static final Uri LOCATION_BASE_URL =
@@ -127,8 +130,6 @@ public class MeLocationRequest {
                                   Log.w(TAG, "JSONException", e);
                               }
                           }
-
-
                       }
                   },
                   new Response.ErrorListener() {
@@ -140,6 +141,28 @@ public class MeLocationRequest {
                       }
                   });
         }
+    }
+
+    /**
+     * Dispatch call of the location API for next page, if the next page is available for previous
+     * call of {@link #get(Context, OnLocationFetched)}.
+     *
+     * @return true, if next page is available
+     */
+    public boolean getNextPage(@NonNull final Context context, @NonNull final OnLocationFetched olf) {
+        if (mNextPage == null) {
+            return false;
+        }
+        Context appContext = context.getApplicationContext();
+
+        if (Debug.isDebuggable(appContext)) {
+            Log.v(TAG, "getNextPage called");
+        }
+        final JsonObjectRequest locationRequest =
+                new LocationApiRequest(appContext, mNextPage, olf);
+        mNextPage = null;
+        VolleySingleton.getInstance(appContext).addToRequestQueue(locationRequest);
+        return true;
     }
 
     public interface OnLocationFetched {

--- a/libLifeLog/src/main/java/com/sonymobile/lifelog/auth/GetTokenJsonRequest.java
+++ b/libLifeLog/src/main/java/com/sonymobile/lifelog/auth/GetTokenJsonRequest.java
@@ -87,11 +87,15 @@ import java.nio.charset.Charset;
         @Override
         public void onErrorResponse(VolleyError error) {
             if (Debug.isDebuggable(mContext)) {
-                Log.w(TAG, "VolleyError, status code: " + error.networkResponse.statusCode
-                        + ", message: " + new String(error.networkResponse.data), error);
+                if (error.networkResponse != null) {
+                    Log.w(TAG, "VolleyError, status code: " + error.networkResponse.statusCode
+                            + ", message: " + new String(error.networkResponse.data), error);
+                } else {
+                    Log.w(TAG, error);
+                }
             }
 
-            if (error.networkResponse.statusCode == 400) {
+            if (error.networkResponse != null && error.networkResponse.statusCode == 400) {
                 if (Debug.isDebuggable(mContext)) {
                     Log.w(TAG, "User may revoked permission of the app from Lifelog service, clear token data.");
                 }


### PR DESCRIPTION
Lifelog API supports pagination for API response. However, there were no way for client app to call next page. I added `getNextPage` API to request data in the next page.

Please refer to page below for pagination of the API response.
https://developer.sony.com/develop/services/lifelog-api/requests-and-responses/#limitingAndPaginatingResults

I hope you will like this patch.